### PR TITLE
Implement SSE and HTTP stream transport options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ To set up and run these MCP servers, you'll need Python 3.8+ and a Check Point M
     ```
     The server will start and wait for an MCP client connection over standard I/O.
 
+    By default, the server uses standard I/O (`stdio`) for communication. You can also specify other transport mechanisms using the `--transport` argument:
+
+    *   **`stdio` (default):** Uses standard input/output.
+        ```bash
+        python src/firewall/server.py
+        ```
+    *   **`sse` (Server-Sent Events):** Runs an HTTP server that clients can connect to for Server-Sent Events.
+        ```bash
+        python src/firewall/server.py --transport sse
+        ```
+        The server will listen on `0.0.0.0:8000` by default when using `sse`.
+    *   **`streamable-http`:** Runs an HTTP server that clients can connect to using a streamable HTTP mechanism.
+        ```bash
+        python src/firewall/server.py --transport streamable-http
+        ```
+        The server will listen on `0.0.0.0:8000` by default when using `streamable-http`.
+
 6.  **Connect an MCP Client:**
     * Use an MCP-compatible AI application (like Anthropic's Claude Desktop, or build/configure your own client) to connect to the running server.
     * Configure the client to recognize your local server running via standard I/O. Refer to your chosen MCP client's documentation for how to add a local server.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ To set up and run these MCP servers, you'll need Python 3.8+ and a Check Point M
         ```
         The server will listen on `0.0.0.0:8000` by default when using `streamable-http`.
 
+    When using `sse` or `streamable-http` transports, you can also specify a custom port using the optional `--port` argument. If not provided, it defaults to `8000`.
+    Example:
+    ```bash
+    python src/firewall/server.py --transport streamable-http --port 9999
+    ```
+
 6.  **Connect an MCP Client:**
     * Use an MCP-compatible AI application (like Anthropic's Claude Desktop, or build/configure your own client) to connect to the running server.
     * Configure the client to recognize your local server running via standard I/O. Refer to your chosen MCP client's documentation for how to add a local server.

--- a/src/firewall/server.py
+++ b/src/firewall/server.py
@@ -409,9 +409,15 @@ def main():
         default='stdio',
         help="Transport mechanism to use (default: stdio)"
     )
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=8000,
+        help='Port to listen on for SSE or Streamable HTTP transport (default: 8000)'
+    )
     args = parser.parse_args()
 
-    print(f"Starting Check Point Firewall MCP server (FastMCP using {args.transport})...")
+    print(f"Starting Check Point Firewall MCP server (FastMCP using {args.transport}, port {args.port if args.transport != 'stdio' else 'N/A'})...")
     try:
         if args.transport == "stdio":
             # Assuming server.run() defaults to stdio or handles transport='stdio'
@@ -420,7 +426,7 @@ def main():
             server.run(
                 transport=args.transport,
                 host="0.0.0.0",
-                port=8000,
+                port=args.port,
                 log_level="info"
             )
         else:

--- a/src/firewall/server.py
+++ b/src/firewall/server.py
@@ -1,3 +1,4 @@
+import argparse
 from mcp.server.fastmcp import FastMCP
 from typing import Dict, Any, List, Optional
 from . import config
@@ -401,11 +402,34 @@ async def firewall_logs() -> str:
     return json.dumps(dummy_logs)
 
 def main():
-    print(f"Starting Check Point Firewall MCP server (FastMCP using stdio)...")
+    parser = argparse.ArgumentParser(description="Check Point Firewall MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=['stdio', 'sse', 'streamable-http'],
+        default='stdio',
+        help="Transport mechanism to use (default: stdio)"
+    )
+    args = parser.parse_args()
+
+    print(f"Starting Check Point Firewall MCP server (FastMCP using {args.transport})...")
     try:
-        server.run()
+        if args.transport == "stdio":
+            # Assuming server.run() defaults to stdio or handles transport='stdio'
+            server.run(transport=args.transport)
+        elif args.transport in ["sse", "streamable-http"]:
+            server.run(
+                transport=args.transport,
+                host="0.0.0.0",
+                port=8000,
+                log_level="info"
+            )
+        else:
+            # Should not happen due to argparse choices
+            print(f"Error: Unknown transport type {args.transport}")
+            return
+
     except Exception as e:
-        error_message = f"PYTHON SERVER CRITICAL ERROR in main server.run(): {e}\n{traceback.format_exc()}"
+        error_message = f"PYTHON SERVER CRITICAL ERROR in main server.run() with transport {args.transport}: {e}\n{traceback.format_exc()}"
         print(error_message)
         with open("fastmcp_server_critical_error.log", "w") as f_err:
             f_err.write(error_message)


### PR DESCRIPTION
This change introduces the ability to run the FastMCP server with different transport protocols: SSE (Server-Sent Events) and Streamable HTTP, in addition to the default STDIO.

Modifications:
- Added command-line argument parsing to `src/firewall/server.py` using `argparse`.
  - A `--transport` argument allows specifying `stdio`, `sse`, or `streamable-http`.
- The `main()` function in `src/firewall/server.py` now configures and runs the FastMCP server with the chosen transport.
  - For `sse` and `streamable-http`, the server defaults to listening on `0.0.0.0:8000` with `log_level="info"`.
- Updated `README.md` to include instructions and examples for using the new transport options.